### PR TITLE
Use ftp-stud.fht-esslingen.de as example CentOS mirror

### DIFF
--- a/image-factory.conf
+++ b/image-factory.conf
@@ -14,7 +14,7 @@ ram=1G
 #upload_destinations=upload-host1,upload-host2
 
 # Select mirrors in your region
-centos_mirror=http://ftp.rz.uni-frankfurt.de/pub/mirrors/centos
+centos_mirror=http://ftp-stud.fht-esslingen.de/pub/Mirrors/centos
 debian_mirror=rsync://ftp.de.debian.org/debian
 ubuntu_mirror=http://de.archive.ubuntu.com/ubuntu
 fedora_mirror=rsync://ftp.fau.de/fedora


### PR DESCRIPTION
http://ftp.rz.uni-frankfurt.de/pub/mirrors/centos does not mirror CentOS any more. So
switch to http://ftp-stud.fht-esslingen.de/pub/Mirrors/centos instead.

Signed-off-by: Anubhav Gupta <anubhav.gupta@ionos.com>