### PR TITLE
Drop Ubuntu 19.10 and CentOS 6 support

### DIFF
--- a/image-factory.conf
+++ b/image-factory.conf
@@ -27,12 +27,6 @@ upload_args=--progress
 # Post upload command can run anything and could trigger further steps after upload
 #post-upload-command=ssh user@upload-host1.example.com ls /srv/${image}
 
-[CentOS-6-server]
-initrd=${centos_mirror}/6/os/x86_64/images/pxeboot/initrd.img
-linux=${centos_mirror}/6/os/x86_64/images/pxeboot/vmlinuz
-kickstart=${data_dir}/CentOS-6-server.cfg
-vnc=localhost:0
-
 [CentOS-7-server]
 ram=3G
 image-size=3G
@@ -159,16 +153,6 @@ linux=${ubuntu_mirror}/dists/${dist}/main/installer-amd64/current/images/${netbo
 preseed=${data_dir}/Ubuntu-19.04-server-de.cfg
 append=auto-install/enable=true hostname=ubuntu vga=771 d-i -- quiet
 vnc=localhost:25
-
-[Ubuntu-19.10-server]
-dist=eoan
-image-size=3G
-netboot=netboot
-initrd=${ubuntu_mirror}/dists/${dist}/main/installer-amd64/current/images/${netboot}/ubuntu-installer/amd64/initrd.gz
-linux=${ubuntu_mirror}/dists/${dist}/main/installer-amd64/current/images/${netboot}/ubuntu-installer/amd64/linux
-preseed=${data_dir}/Ubuntu-19.10-server-de.cfg
-append=auto-install/enable=true hostname=ubuntu vga=771 d-i -- quiet
-vnc=localhost:26
 
 [Ubuntu-20.04-LTS-server]
 dist=focal


### PR DESCRIPTION
Since Ubuntu 19.10 reached EOL on July 2020 i.e.
https://lists.ubuntu.com/archives/ubuntu-announce/2020-July/000258.html
and CentOS 6 on November 2020, i.e.
https://cloud.google.com/compute/docs/eol/centos6
This commit shall remove the support.

Signed-off-by: Anubhav Gupta <anubhav.gupta@ionos.com>