### PR TITLE
Increase CentOS 7 image size to 4 GiB

### DIFF
--- a/image-factory.conf
+++ b/image-factory.conf
@@ -35,7 +35,7 @@ vnc=localhost:0
 
 [CentOS-7-server]
 ram=3G
-image-size=3G
+image-size=4G
 initrd=${centos_mirror}/7/os/x86_64/images/pxeboot/initrd.img
 linux=${centos_mirror}/7/os/x86_64/images/pxeboot/vmlinuz
 append=net.ifnames=1


### PR DESCRIPTION
The image building fails for CentOS 7 when the image size is set to
3 GiB, because the installer runs out of disk space.

Therefore increase the image size from 3 GiB to 4 GiB.

Signed-off-by: Anubhav Gupta <anubhav.gupta@ionos.com>