### PR TITLE
Add Debian 11

### DIFF
--- a/image-factory.conf
+++ b/image-factory.conf
@@ -94,6 +94,14 @@ preseed=${data_dir}/Debian-10-server-minimal-de.cfg
 append=auto-install/enable=true keymap=us hostname=debian domain=unassigned-domain vga=771 d-i -- quiet
 vnc=localhost:14
 
+[Debian-11-server]
+dist=bullseye
+initrd=${debian_mirror}/dists/${dist}/main/installer-amd64/current/images/netboot/debian-installer/amd64/initrd.gz
+linux=${debian_mirror}/dists/${dist}/main/installer-amd64/current/images/netboot/debian-installer/amd64/linux
+preseed=${data_dir}/Debian-11-server-de.cfg
+append=auto-install/enable=true keymap=us hostname=debian domain=unassigned-domain vga=771 d-i -- quiet
+vnc=localhost:16
+
 [Debian-testing-server]
 dist=bullseye
 initrd=https://d-i.debian.org/daily-images/amd64/daily/netboot/debian-installer/amd64/initrd.gz


### PR DESCRIPTION
Since Debian 11 (Bullseye) was released on 14 August 2021
i.e. https://www.debian.org/releases/bullseye/
This commit shall add the support of debian 11 to
image-factory

Signed-off-by: Anubhav Gupta <anubhav.gupta@ionos.com>